### PR TITLE
Exempt library source files from ReSharper auto-formatting

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -157,6 +157,11 @@ satisfying the requirements of section 4a of the License. In practice, this mean
 library in binary releases of your own software without having to also include this notice, a copy of the Licence, or
 any other copyright attribution.
 */
+
+// @formatter:off
+"@
+        $FileFooter = @"
+// @formatter:on
 "@
 
         # Locate source files to be included in the package, and generate their corresponding .pp files.
@@ -168,7 +173,7 @@ any other copyright attribution.
             if ($OriginalContents -ne $ModifiedContents) {
                 Write-Host "  Including file $InputPath"
                 
-                $ModifiedContents = "$FileHeader`r`n`r`n$ModifiedContents"
+                $ModifiedContents = "$FileHeader`r`n`r`n$ModifiedContents`r`n`r`n$FileFooter"
                 
                 $OutputPath = "$InputPath.pp"
                 Write-Host "    Rewriting to $OutputPath"

--- a/Source/ULibs.ShellEscape/RELEASENOTES.md
+++ b/Source/ULibs.ShellEscape/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.ShellEscape release notes
 
+## 0.1.1
+
+### Features
+
+- Excluded this library's source code from ReSharper's formatting operations, so that users who apply project-wide style and formatting changes won't accidentally modify this library's source code, which could lead to package upgrade problems. 
+
 ## 0.1.0
 
 ### Features


### PR DESCRIPTION
Adds tokens into the deployed source files to ensure that they are unaffected by ReSharper's automated formatting.