### PR TITLE
Enable compatibility analyzer, and fix issue in TinyJsonSer

### DIFF
--- a/Source/ULibs.FullExceptionString/ULibs.FullExceptionString.csproj
+++ b/Source/ULibs.FullExceptionString/ULibs.FullExceptionString.csproj
@@ -5,4 +5,8 @@
     <Copyright>2018</Copyright>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
+  </ItemGroup>
+
 </Project>

--- a/Source/ULibs.ShellEscape/ULibs.ShellEscape.csproj
+++ b/Source/ULibs.ShellEscape/ULibs.ShellEscape.csproj
@@ -5,4 +5,8 @@
     <Copyright>2017</Copyright>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
+  </ItemGroup>
+
 </Project>

--- a/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.csproj
+++ b/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.csproj
@@ -5,4 +5,8 @@
     <Copyright>2018</Copyright>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
+  </ItemGroup>
+
 </Project>

--- a/Source/ULibs.TinyJsonSer/JsonSerializer.cs
+++ b/Source/ULibs.TinyJsonSer/JsonSerializer.cs
@@ -191,7 +191,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonSer
                 var newIndentLevel = indentLevel + 1;
                 var newIndent = GetIndent(newIndentLevel);
                 bool isFirstElement = true;
-                foreach (DictionaryEntry entry in dictionary)
+                foreach (var key in dictionary.Keys)
                 {
                     if (isFirstElement)
                     {
@@ -203,9 +203,9 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonSer
                     }
 
                     writeString(newIndent);
-                    SerializeString(entry.Key.ToString(), writeString, writeChar);
+                    SerializeString(key.ToString(), writeString, writeChar);
                     writeString(_keyValueSeparator);
-                    Serialize(entry.Value, writeString, writeChar, newIndentLevel);
+                    Serialize(dictionary[key], writeString, writeChar, newIndentLevel);
                 }
 
                 writeString(GetIndent(indentLevel));

--- a/Source/ULibs.TinyJsonSer/RELEASENOTES.md
+++ b/Source/ULibs.TinyJsonSer/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.TinyJsonSer release notes
 
+## 1.0.2
+
+### Improvements
+
+- Removed use of `DictionaryEntry` type, to improve cross-platform compatibility.
+
 ## 1.0.1
 
 ### Improvements

--- a/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.csproj
+++ b/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.csproj
@@ -5,4 +5,8 @@
     <Copyright>2016</Copyright>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
+  </ItemGroup>
+
 </Project>

--- a/Source/ULibs.UlibsProjectTemplate/ULibs.UlibsProjectTemplate.csproj
+++ b/Source/ULibs.UlibsProjectTemplate/ULibs.UlibsProjectTemplate.csproj
@@ -5,4 +5,8 @@
     <Copyright>2017</Copyright>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Enabled to Microsoft.DotNet.Compatibility.Analyzer, and fixed a compatibility issue in TinyJsonSer, whereby DictionaryEntry is deprecated.