### PR TITLE
Fixed #10: Correct handling of ExpandoObject and dictionary types

### DIFF
--- a/Source/ULibs.TinyJsonSer/RELEASENOTES.md
+++ b/Source/ULibs.TinyJsonSer/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.TinyJsonSer release notes
 
+## 1.0.3
+
+### Bug fixes
+
+- Bug 10: Correctly serialise a dynamic `ExpandoObject` as a json object rather than a json array.
+
 ## 1.0.2
 
 ### Improvements

--- a/Source/Ulibs.Tests/TinyJsonSer/CustomDictionary.cs
+++ b/Source/Ulibs.Tests/TinyJsonSer/CustomDictionary.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Ulibs.Tests.TinyJsonSer
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IDictionary{TKey,TValue}"/>
+    /// that doesn't implement any other collection interface.
+    /// </summary>
+    public class CustomDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly TKey _key;
+        private readonly TValue _value;
+
+        public CustomDictionary(TKey key, TValue value)
+        {
+            _key = key;
+            _value = value;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            yield return new KeyValuePair<TKey, TValue>(_key, _value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(KeyValuePair<TKey, TValue> item) =>
+            EqualityComparer<TKey>.Default.Equals(item.Key, _key) &&
+            EqualityComparer<TValue>.Default.Equals(item.Value, _value);
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            array[arrayIndex] = new KeyValuePair<TKey, TValue>(_key, _value);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item) => throw new NotSupportedException();
+
+        public int Count => 1;
+        public bool IsReadOnly => true;
+        public bool ContainsKey(TKey key) => EqualityComparer<TKey>.Default.Equals(key, _key);
+
+        public void Add(TKey key, TValue value) => throw new NotSupportedException();
+
+        public bool Remove(TKey key) => throw new NotSupportedException();
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            value = _value;
+            return ContainsKey(key);
+        }
+
+        public TValue this[TKey key]
+        {
+            get => ContainsKey(key) ? _value : throw new KeyNotFoundException();
+            set => throw new NotSupportedException();
+        }
+
+        public ICollection<TKey> Keys => new[] {_key};
+        public ICollection<TValue> Values => new[] {_value};
+    }
+}

--- a/Source/Ulibs.Tests/TinyJsonSer/CustomEnumerable.cs
+++ b/Source/Ulibs.Tests/TinyJsonSer/CustomEnumerable.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Ulibs.Tests.TinyJsonSer
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IEnumerable{T}"/> that doesn't implement any other
+    /// collection interface.
+    /// </summary>
+    public class CustomEnumerable<T> : IEnumerable<T>
+    {
+        private readonly T _item;
+
+        public CustomEnumerable(T item)
+        {
+            _item = item;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            yield return _item;
+        }
+    }
+}

--- a/Source/Ulibs.Tests/TinyJsonSer/CustomReadOnlyCollection.cs
+++ b/Source/Ulibs.Tests/TinyJsonSer/CustomReadOnlyCollection.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Ulibs.Tests.TinyJsonSer
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IReadOnlyCollection{T}"/> that doesn't implement any other
+    /// collection interface.
+    /// </summary>
+    public class CustomReadOnlyCollection<T> : IReadOnlyCollection<T>
+    {
+        private readonly T _item;
+
+        public CustomReadOnlyCollection(T item)
+        {
+            _item = item;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            yield return _item;
+        }
+
+        public int Count => 1;
+    }
+}

--- a/Source/Ulibs.Tests/TinyJsonSer/CustomReadOnlyDictionary.cs
+++ b/Source/Ulibs.Tests/TinyJsonSer/CustomReadOnlyDictionary.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Ulibs.Tests.TinyJsonSer
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IReadOnlyDictionary{TKey,TValue}"/>
+    /// that doesn't implement any other collection interface.
+    /// </summary>
+    public class CustomReadOnlyDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+    {
+        private readonly TKey _key;
+        private readonly TValue _value;
+
+        public CustomReadOnlyDictionary(TKey key, TValue value)
+        {
+            _key = key;
+            _value = value;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            yield return new KeyValuePair<TKey, TValue>(_key, _value);
+        }
+
+        public int Count => 1;
+
+        public bool ContainsKey(TKey key) => EqualityComparer<TKey>.Default.Equals(key, _key);
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            value = _value;
+            return ContainsKey(_key);
+        }
+
+        public TValue this[TKey key] => ContainsKey(key) ? _value : throw new KeyNotFoundException();
+
+        public IEnumerable<TKey> Keys
+        {
+            get { yield return _key; }
+        }
+
+        public IEnumerable<TValue> Values
+        {
+            get { yield return _value; }
+        }
+    }
+}

--- a/Source/Ulibs.Tests/TinyJsonSer/CustomReadOnlyList.cs
+++ b/Source/Ulibs.Tests/TinyJsonSer/CustomReadOnlyList.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Ulibs.Tests.TinyJsonSer
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IReadOnlyList{T}"/> that doesn't implement any other
+    /// collection interface.
+    /// </summary>
+    public class CustomReadOnlyList<T> : IReadOnlyList<T>
+    {
+        private readonly T _item;
+
+        public CustomReadOnlyList(T item)
+        {
+            _item = item;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            yield return _item;
+        }
+
+        public int Count => 1;
+
+        public T this[int index] => index == 0 ? _item : throw new IndexOutOfRangeException();
+    }
+}

--- a/Source/Ulibs.Tests/TinyJsonSer/JsonSerializerTests.cs
+++ b/Source/Ulibs.Tests/TinyJsonSer/JsonSerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;
@@ -279,6 +280,95 @@ namespace Ulibs.Tests.TinyJsonSer
                                               },
                                               ["ghi"] = false
                                           }).SetName("dictionary (with nested elements)");
+            dynamic expando = new ExpandoObject();
+            expando.SomeProperty = 123;
+            yield return new TestCaseData(true, expando).SetName("ExpandoObject");
+
+            yield return new TestCaseData(true, new CustomEnumerable<string>("ABC")).SetName("Custom IEnumerable<string>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomEnumerable<KeyValuePair<string, object>>(
+                        new KeyValuePair<string, object>("ABC", 123)))
+               .SetName("Custom IEnumerable<KeyValuePair<string, object>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomEnumerable<KeyValuePair<string, string>>(
+                        new KeyValuePair<string, string>("ABC", "123")))
+               .SetName("Custom IEnumerable<KeyValuePair<string, string>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomEnumerable<KeyValuePair<object, object>>(
+                        new KeyValuePair<object, object>("ABC", 123)))
+               .SetName("Custom IEnumerable<KeyValuePair<object, object>>");
+
+            yield return new TestCaseData(true, new CustomReadOnlyCollection<string>("ABC")).SetName(
+                "Custom IReadOnlyCollection<string>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyCollection<KeyValuePair<string, object>>(
+                        new KeyValuePair<string, object>("ABC", 123)))
+               .SetName("Custom IReadOnlyCollection<KeyValuePair<string, object>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyCollection<KeyValuePair<string, string>>(
+                        new KeyValuePair<string, string>("ABC", "123")))
+               .SetName("Custom IReadOnlyCollection<KeyValuePair<string, string>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyCollection<KeyValuePair<object, object>>(
+                        new KeyValuePair<object, object>("ABC", "123")))
+               .SetName("Custom IReadOnlyCollection<KeyValuePair<object, object>>");
+
+            yield return new TestCaseData(true, new CustomReadOnlyList<string>("ABC")).SetName(
+                "Custom IReadOnlyList<string>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyList<KeyValuePair<string, object>>(
+                        new KeyValuePair<string, object>("ABC", 123)))
+               .SetName("Custom IReadOnlyList<KeyValuePair<string, object>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyList<KeyValuePair<string, string>>(
+                        new KeyValuePair<string, string>("ABC", "123")))
+               .SetName("Custom IReadOnlyList<KeyValuePair<string, string>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyList<KeyValuePair<object, object>>(
+                        new KeyValuePair<object, object>("ABC", "123")))
+               .SetName("Custom IReadOnlyList<KeyValuePair<object, object>>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyDictionary<string, object>("ABC", 123))
+               .SetName("Custom IReadOnlyDictionary<string, object>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyDictionary<string, string>("ABC", "123"))
+               .SetName("Custom IReadOnlyDictionary<string, string>");
+
+            yield return new TestCaseData(
+                    true,
+                    new CustomReadOnlyDictionary<object, object>("ABC", "123"))
+               .SetName("Custom IReadOnlyDictionary<object, object>");
+
+            yield return new TestCaseData(true, new CustomDictionary<string, object>("ABC", 123))
+               .SetName("Custom IDictionary<string, object>");
+
+            yield return new TestCaseData(true, new CustomDictionary<string, string>("ABC", "123"))
+               .SetName("Custom IDictionary<string, string>");
+
+            yield return new TestCaseData(true, new CustomDictionary<object, object>("ABC", "123"))
+               .SetName("Custom IDictionary<object, object>");
         }
 
         [Flags]

--- a/Source/Ulibs.Tests/Ulibs.Tests.csproj
+++ b/Source/Ulibs.Tests/Ulibs.Tests.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -47,6 +48,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShellEscape\StringExtensionsTests.cs" />
     <Compile Include="TinyJsonDeser\JsonDeserializerTests.cs" />
+    <Compile Include="TinyJsonSer\CustomDictionary.cs" />
+    <Compile Include="TinyJsonSer\CustomEnumerable.cs" />
+    <Compile Include="TinyJsonSer\CustomReadOnlyCollection.cs" />
+    <Compile Include="TinyJsonSer\CustomReadOnlyDictionary.cs" />
+    <Compile Include="TinyJsonSer\CustomReadOnlyList.cs" />
     <Compile Include="TinyJsonSer\JsonSerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -69,6 +75,9 @@
       <Project>{3960af49-22de-489e-8348-35e32c605b4c}</Project>
       <Name>ULibs.TinyJsonSer</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Provides correct serialisation of `ExpandoObject` and implementations of `IDictionary<TKey, TValue>` and `IReadOnlyDictionary<TKey, TValue>` beyond the common implementions available in the framework libraries.

Fixes #10.