### PR TITLE
Add support for PackageReferences

### DIFF
--- a/Source/ULibs.FullExceptionString/RELEASENOTES.md
+++ b/Source/ULibs.FullExceptionString/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.FullExceptionString release notes
 
+## 1.0.1
+
+### Features
+
+- Supports being referenced with Package Reference
+
 ## 1.0.0
 
 ### Features

--- a/Source/ULibs.FullExceptionString/ULibs.FullExceptionString.nuspec
+++ b/Source/ULibs.FullExceptionString/ULibs.FullExceptionString.nuspec
@@ -15,5 +15,6 @@
   </metadata>
   <files>
     <file src="*.pp" target="content\App_Packages\RedGate.ULibs.FullExceptionString.$version$"/>
+    <file src="*.pp" target="contentFiles\cs\any\RedGate.ULibs.FullExceptionString"/>
   </files>
 </package>

--- a/Source/ULibs.ShellEscape/RELEASENOTES.md
+++ b/Source/ULibs.ShellEscape/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.ShellEscape release notes
 
+## 1.0.1
+
+### Features
+
+- Supports being referenced with Package Reference
+
 ## 1.0.0
 
 ### Features

--- a/Source/ULibs.ShellEscape/ULibs.ShellEscape.nuspec
+++ b/Source/ULibs.ShellEscape/ULibs.ShellEscape.nuspec
@@ -15,5 +15,6 @@
   </metadata>
   <files>
     <file src="*.pp" target="content\App_Packages\RedGate.ULibs.ShellEscape.$version$"/>
+    <file src="*.pp" target="contentFiles\cs\any\RedGate.ULibs.ShellEscape"/>
   </files>
 </package>

--- a/Source/ULibs.TinyJsonDeser/RELEASENOTES.md
+++ b/Source/ULibs.TinyJsonDeser/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.TinyJsonDeser release notes
 
+## 1.0.2
+
+### Features
+
+- Supports being referenced with Package Reference
+
 ## 1.0.1
 
 ### Features

--- a/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.nuspec
+++ b/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.nuspec
@@ -15,5 +15,6 @@
   </metadata>
   <files>
     <file src="*.pp" target="content\App_Packages\RedGate.ULibs.TinyJsonDeser.$version$"/>
+    <file src="*.pp" target="contentFiles\cs\any\RedGate.ULibs.TinyJsonDeser"/>
   </files>
 </package>

--- a/Source/ULibs.TinyJsonSer/RELEASENOTES.md
+++ b/Source/ULibs.TinyJsonSer/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.TinyJsonSer release notes
 
+## 1.0.4
+
+### Features
+
+- Supports being referenced with Package Reference
+
 ## 1.0.3
 
 ### Bug fixes

--- a/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.nuspec
+++ b/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.nuspec
@@ -15,5 +15,6 @@
   </metadata>
   <files>
     <file src="*.pp" target="content\App_Packages\RedGate.ULibs.TinyJsonSer.$version$"/>
+    <file src="*.pp" target="contentFiles\cs\any\RedGate.ULibs.TinyJsonSer"/>
   </files>
 </package>

--- a/Source/ULibs.UlibsProjectTemplate/ULibs.UlibsProjectTemplate.nuspec
+++ b/Source/ULibs.UlibsProjectTemplate/ULibs.UlibsProjectTemplate.nuspec
@@ -15,5 +15,6 @@
   </metadata>
   <files>
     <file src="*.pp" target="content\App_Packages\RedGate.ULibs.UlibsProjectTemplate.$version$"/>
+    <file src="*.pp" target="contentFiles\cs\any\RedGate.ULibs.UlibsProjectTemplate"/>
   </files>
 </package>


### PR DESCRIPTION
When using PackageReference to pull in NuGet you need to use the contentFiles rather than content folder. This PR updates existing libraries and the template to support the new format.

As described by https://docs.microsoft.com/en-us/nuget/create-packages/source-and-config-file-transformations we also add the files to `contentFiles\cs\any\`

Changes:
- In PackageReference the files are not put into the solution (instead are pulled from the package folder). This functionally makes the source immutable
- No need to include the App_Packages as it isn't in the project
- No need for version as this is now all handled by the package version

I tested this by creating a new format project and including these new packages. It would then successfully compile and I could reference the code e.g. `TestSourcePackages.ULibs.TinyJsonSer.JsonSerializer`