### PR TITLE
Use C#8 and reference type nullability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _ReSharper*/
 
 # Ignore executables.
 *.exe
+
+# Ignore Jetbrains files
+**/.idea/*

--- a/Source/ULibs.TinyJsonDeser/JsonDeserializer.cs
+++ b/Source/ULibs.TinyJsonDeser/JsonDeserializer.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
-/***using System.Diagnostics.CodeAnalysis;***/
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -60,7 +60,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
         /// <c>bool</c>, a <c>string</c>, a <c>double</c>, an <c>object[]</c>, an <c>IDictionary&lt;string, object&gt;</c>
         /// or <c>null</c>.</param>
         /// <returns>Whether or not the parse attempt succeeded.</returns>
-        public bool TryParseValue(string json, out object output)
+        public bool TryParseValue(string json, out object? output)
         {
             if (json == null) throw new ArgumentNullException(nameof(json));
 
@@ -144,7 +144,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
         /// <param name="json">The json string to parse.</param>
         /// <param name="output">If the parse succeeded, this will hold the parsed result.</param>
         /// <returns>Whether or not the parse attempt succeeded.</returns>
-        public bool TryParseArray(string json, out object[] output)
+        public bool TryParseArray(string json, out object?[] output)
         {
             if (json == null) throw new ArgumentNullException(nameof(json));
 
@@ -161,7 +161,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
         /// <param name="json">The json string to parse.</param>
         /// <param name="output">If the parse succeeded, this will hold the parsed result.</param>
         /// <returns>Whether or not the parse attempt succeeded.</returns>
-        public bool TryParseObject(string json, out IDictionary<string, object> output)
+        public bool TryParseObject(string json, out IDictionary<string, object?> output)
         {
             if (json == null) throw new ArgumentNullException(nameof(json));
 
@@ -177,7 +177,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
             while (offset < json.Length && char.IsWhiteSpace(json[offset])) offset++;
         }
 
-        private static bool TryParseValue(string json, ref int offset, out object output)
+        private static bool TryParseValue(string json, ref int offset, out object? output)
         {
             if (offset < json.Length)
             {
@@ -367,7 +367,6 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
 
         private static bool TryParseString(string json, ref int offset, out string output)
         {
-            output = null;
             var index = offset;
             if (index < json.Length && json[index] == '"')
             {
@@ -392,14 +391,14 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                             }
                             else
                             {
-                                output = null;
+                                output = DefaultString;
                                 return false;
                             }
 
                             break;
 
                         case var ch when ch < ' ':
-                            output = null;
+                            output = DefaultString;
                             return false;
 
                         default:
@@ -409,7 +408,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                 }
             }
 
-            output = null;
+            output = DefaultString;
             return false;
         }
 
@@ -480,7 +479,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
         private static bool IsHexDigit(char ch) =>
             (ch >= '0' && ch <= '9') | (ch >= 'a' && ch <= 'f') | (ch >= 'A' && ch <= 'F');
 
-        private static bool TryParseArray(string json, ref int offset, out object[] output)
+        private static bool TryParseArray(string json, ref int offset, out object?[] output)
         {
             var index = offset;
             if (index < json.Length && json[index] == '[')
@@ -498,7 +497,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                         return true;
                     }
 
-                    var list = new List<object>();
+                    var list = new List<object?>();
 
                     SkipWhiteSpace(json, ref index);
                     if (TryParseValue(json, ref index, out var firstElement))
@@ -507,7 +506,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                     }
                     else
                     {
-                        output = null;
+                        output = DefaultArray;
                         return false;
                     }
 
@@ -532,31 +531,31 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                                     }
                                     else
                                     {
-                                        output = null;
+                                        output = DefaultArray;
                                         return false;
                                     }
 
                                     break;
 
                                 default:
-                                    output = null;
+                                    output = DefaultArray;
                                     return false;
                             }
                         }
                         else
                         {
-                            output = null;
+                            output = DefaultArray;
                             return false;
                         }
                     }
                 }
             }
 
-            output = null;
+            output = DefaultArray;
             return false;
         }
 
-        private static bool TryParseObject(string json, ref int offset, out IDictionary<string, object> output)
+        private static bool TryParseObject(string json, ref int offset, out IDictionary<string, object?> output)
         {
             var index = offset;
             if (index < json.Length && json[index] == '{')
@@ -567,7 +566,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
 
                 if (index < json.Length)
                 {
-                    var map = new SortedDictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
+                    var map = new SortedDictionary<string, object?>(StringComparer.InvariantCultureIgnoreCase);
 
                     if (json[index] == '}')
                     {
@@ -583,7 +582,7 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                     }
                     else
                     {
-                        output = null;
+                        output = DefaultObject;
                         return false;
                     }
 
@@ -609,32 +608,32 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                                     }
                                     else
                                     {
-                                        output = null;
+                                        output = DefaultObject;
                                         return false;
                                     }
 
                                     break;
 
                                 default:
-                                    output = null;
+                                    output = DefaultObject;
                                     return false;
                             }
                         }
                         else
                         {
-                            output = null;
+                            output = DefaultObject;
                             return false;
                         }
                     }
                 }
             }
 
-            output = null;
+            output = DefaultObject;
             return false;
         }
 
         private static bool TryParseObjectKeyValuePair(string json, ref int offset,
-                                                       out KeyValuePair<string, object> output)
+                                                       out KeyValuePair<string, object?> output)
         {
             var index = offset;
             if (TryParseString(json, ref index, out var key))
@@ -646,15 +645,19 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonDeser
                     SkipWhiteSpace(json, ref index);
                     if (TryParseValue(json, ref index, out var value))
                     {
-                        output = new KeyValuePair<string, object>(key, value);
+                        output = new KeyValuePair<string, object?>(key, value);
                         offset = index;
                         return true;
                     }
                 }
             }
 
-            output = default(KeyValuePair<string, object>);
+            output = default;
             return false;
         }
+
+        private const string DefaultString = "";
+        private static IDictionary<string, object?> DefaultObject => new Dictionary<string, object?>();
+        private static readonly object?[] DefaultArray = new object?[0];
     }
 }

--- a/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.csproj
+++ b/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>2018</Copyright>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/ULibs.TinyJsonSer/JsonSerializer.cs
+++ b/Source/ULibs.TinyJsonSer/JsonSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -202,8 +203,8 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonSer
         {
             var properties = new List<KeyValuePair<string, object>>();
 
-            PropertyInfo keyInfo = null;
-            PropertyInfo valueInfo = null;
+            PropertyInfo? keyInfo = null;
+            PropertyInfo? valueInfo = null;
             foreach (var item in enumerable)
             {
                 if (keyInfo == null)
@@ -213,11 +214,10 @@ namespace /***$rootnamespace$.***/ULibs.TinyJsonSer
                     valueInfo = type.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
                 }
 
-                // ReSharper disable PossibleNullReferenceException
-                var key = keyInfo.GetValue(item).ToString();
-                var value = valueInfo.GetValue(item);
-                // ReSharper restore PossibleNullReferenceException
-                properties.Add(new KeyValuePair<string, object>(key, value));
+                var key = keyInfo?.GetValue(item).ToString();
+                var value = valueInfo?.GetValue(item);
+
+                properties.Add(new KeyValuePair<string, object>(key!, value!));
             }
 
             SerializeObjectProperties(properties, writeString, writeChar, indentLevel);

--- a/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.csproj
+++ b/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>2016</Copyright>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Ulibs.Tests/TinyJsonDeser/JsonDeserializerTests.cs
+++ b/Source/Ulibs.Tests/TinyJsonDeser/JsonDeserializerTests.cs
@@ -173,6 +173,7 @@ namespace Ulibs.Tests.TinyJsonDeser
         [TestCase("[12]", new object[] {12}, TestName = "Array with single element having multiple characters")]
         [TestCase("[1,2]", new object[] {1, 2}, TestName = "Array with multiple elements")]
         [TestCase("[ 1 , 2 ]", new object[] {1, 2}, TestName = "Array with multiple elements and internal whitespace")]
+        [TestCase("[null]", new object[] {null}, TestName = "Array with single null element")]
         [TestCase("[[1,2],[3,4]]", new object[] {new object[] {1, 2}, new object[] {3, 4}}, TestName = "Array with nested array elements")]
         public void TestTryParseArray_Sucess(string json, object[] expected)
         {
@@ -217,6 +218,9 @@ namespace Ulibs.Tests.TinyJsonDeser
             yield return new TestCaseData("{ \"abc\" : 123 }",
                                           new Dictionary<string, object> {["abc"] = 123})
                .SetName("Object with single key-value pair and internal whitespace");
+            yield return new TestCaseData("{\"abc\":null}",
+                                          new Dictionary<string, object> {["abc"] = null})
+               .SetName("Object with single key-value pair and null value");
             yield return new TestCaseData("{\"abc\":123,\"def\":4.5}",
                                           new Dictionary<string, object> {["abc"] = 123, ["def"] = 4.5})
                .SetName("Object with multiple key-value pairs");
@@ -249,6 +253,7 @@ namespace Ulibs.Tests.TinyJsonDeser
         [TestCase("{\"abc\":123,\"def\":4.5,}", TestName = "Missing first key-value pair")]
         [TestCase("{\"abc\":123,,\"def\":4.5}", TestName = "Missing middle key-value pair")]
         [TestCase("{\"abc\":123,\"ABC\":4.5}", TestName = "Duplicate keys")]
+        [TestCase("{null:123}", TestName = "Null key")]
         public void TestTryParseObject_Failed(string json)
         {
             Assert.That(new JsonDeserializer().TryParseObject(json, out var output), Is.False);
@@ -268,6 +273,8 @@ namespace Ulibs.Tests.TinyJsonDeser
             yield return new TestCaseData("1234.5", 1234.5).SetName("Number");
             yield return new TestCaseData("\"abc\"", "abc").SetName("String");
             yield return new TestCaseData("[12,34]", new object[] {12, 34}).SetName("Array");
+            yield return new TestCaseData("[null]", new object[] {null}).SetName("Array null");
+            yield return new TestCaseData("{\"abc\":null}", new Dictionary<string, object>{["abc"] = null}).SetName("Null value");
             yield return new TestCaseData("{\"abc\":123}", new Dictionary<string, object>{["abc"] = 123}).SetName("Object");
         }
 


### PR DESCRIPTION
Team Orca are using C#8 and have enabled C#8 nullability checks so when we build our projects we see lots of nullability warnings from these libraries. Hopefully enabling this feature here will resolve these warnings.