### PR TITLE
More C# nullability clean-up

### DIFF
--- a/Source/ULibs.FullExceptionString/Extensions.cs
+++ b/Source/ULibs.FullExceptionString/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 /***using System.Diagnostics.CodeAnalysis;***/
 using System.IO;
 using System.Linq;

--- a/Source/ULibs.FullExceptionString/ULibs.FullExceptionString.csproj
+++ b/Source/ULibs.FullExceptionString/ULibs.FullExceptionString.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>2018</Copyright>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
-  </ItemGroup>
 
 </Project>

--- a/Source/ULibs.ShellEscape/StringExtensions.cs
+++ b/Source/ULibs.ShellEscape/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 /***using System.Diagnostics.CodeAnalysis;***/
 using System.Text.RegularExpressions;
 

--- a/Source/ULibs.ShellEscape/ULibs.ShellEscape.csproj
+++ b/Source/ULibs.ShellEscape/ULibs.ShellEscape.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>2017</Copyright>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
-  </ItemGroup>
 
 </Project>

--- a/Source/ULibs.TinyJsonDeser/JsonDeserializer.cs
+++ b/Source/ULibs.TinyJsonDeser/JsonDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+/***using System.Diagnostics.CodeAnalysis;***/
 using System.Globalization;
 using System.Linq;
 using System.Text;

--- a/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.csproj
+++ b/Source/ULibs.TinyJsonDeser/ULibs.TinyJsonDeser.csproj
@@ -7,8 +7,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
-  </ItemGroup>
-
 </Project>

--- a/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.csproj
+++ b/Source/ULibs.TinyJsonSer/ULibs.TinyJsonSer.csproj
@@ -7,8 +7,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
-  </ItemGroup>
-
 </Project>

--- a/Source/ULibs.UlibsProjectTemplate/Class1.cs
+++ b/Source/ULibs.UlibsProjectTemplate/Class1.cs
@@ -1,4 +1,5 @@
-﻿/***using System.Diagnostics.CodeAnalysis;***/
+﻿#nullable enable
+/***using System.Diagnostics.CodeAnalysis;***/
 
 namespace /***$rootnamespace$.***/ULibs.UlibsProjectTemplate
 {

--- a/Source/ULibs.UlibsProjectTemplate/ULibs.UlibsProjectTemplate.csproj
+++ b/Source/ULibs.UlibsProjectTemplate/ULibs.UlibsProjectTemplate.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>2017</Copyright>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a follow-up PR to #16 that makes the following changes:

- Updates the remaining micro-library projects to enable nullability checking.
- Removes references to the now defunct Microsoft.DotNet.Analyzers.Compatibility package, since we're now targeting netstandard2.0 rather than net461.
- Adds a missing `/***using System.Diagnostics.CodeAnalysis;***/` comment to JsonDeserializer.

