### PR TITLE
Optionally add DoNotCaptureVariables attributes

### DIFF
--- a/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
+++ b/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
@@ -1,7 +1,11 @@
 # ULibs.SqlClientCompatibility release notes
 
+## 0.1.1
+
+### Features
+- If the SMARTASSEMBLY compile constant is set, DoNotCapture attribute will be applied to the connectionString parameter.
+
 ## 0.1.0
 
 ### Features
-
 - Extension method AddTrustServerCertificateForCompatibility for SqlConnectionStringBuilder, DbConnectionStringBuilder, and connection string.

--- a/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
+++ b/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
@@ -3,7 +3,7 @@
 ## 0.1.1
 
 ### Features
-- If the SMARTASSEMBLY compile constant is set, DoNotCapture attribute will be applied to the connectionString parameter.
+- If the SMARTASSEMBLY compile constant is set, DoNotCaptureVariables attribute will be applied methods that process connection strings.
 
 ## 0.1.0
 

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -29,6 +29,9 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
         /// this should already be the case in 2020!
         /// </para>
         /// </summary>
+#if SMARTASSEMBLY
+[DoNotCaptureVariables]
+#endif
         internal static void AddTrustServerCertificateForCompatibility(this SqlConnectionStringBuilder builder)
         {
             var encrypt = builder.Encrypt;
@@ -55,6 +58,9 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
         /// this should already be the case in 2020!
         /// </para>
         /// </summary>
+#if SMARTASSEMBLY
+[DoNotCaptureVariables]
+#endif
         internal static void AddTrustServerCertificateForCompatibility(this DbConnectionStringBuilder builder)
         {
             if (builder is SqlConnectionStringBuilder sqlBuilder)
@@ -94,17 +100,19 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
         /// this should already be the case in 2020!
         /// </para>
         /// </summary>
-        internal static string AddTrustServerCertificateForCompatibility(
 #if SMARTASSEMBLY
-[DoNotCapture]
+[DoNotCaptureVariables]
 #endif
-            this string connectionString)
+        internal static string AddTrustServerCertificateForCompatibility(this string connectionString)
         {
             var builder = new DbConnectionStringBuilder {ConnectionString = connectionString};
             builder.AddTrustServerCertificateForCompatibility();
             return builder.ConnectionString;
         }
 
+#if SMARTASSEMBLY
+[DoNotCaptureVariables]
+#endif
         private static bool EncryptIsSet(this DbConnectionStringBuilder builder)
         {
             return builder.ContainsKey("Encrypt") && ConvertToBoolean(builder["Encrypt"]);
@@ -133,6 +141,9 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             return ((IConvertible) value).ToBoolean(CultureInfo.InvariantCulture);
         }
 
+#if SMARTASSEMBLY
+[DoNotCaptureVariables]
+#endif
         private static bool IsAzureAuth(this DbConnectionStringBuilder builder)
         {
             return builder.ContainsKey("Authentication") && IsAzureAuth(builder["Authentication"]);
@@ -148,6 +159,9 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             return withSpace >= 0 || withoutSpace >= 0;
         }
 
+#if SMARTASSEMBLY
+[DoNotCaptureVariables]
+#endif
         private static string? GetServer(this DbConnectionStringBuilder builder)
         {
             if (builder.TryGetValue("Data Source", out var ds) && ds is string dss) return dss;

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Data.SqlClient;
+#if SMARTASSEMBLY
+using SmartAssembly.Attributes;
+#endif
 
 namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
 {
@@ -91,7 +94,11 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
         /// this should already be the case in 2020!
         /// </para>
         /// </summary>
-        internal static string AddTrustServerCertificateForCompatibility(this string connectionString)
+        internal static string AddTrustServerCertificateForCompatibility(
+#if SMARTASSEMBLY
+[DoNotCapture]
+#endif
+            this string connectionString)
         {
             var builder = new DbConnectionStringBuilder {ConnectionString = connectionString};
             builder.AddTrustServerCertificateForCompatibility();


### PR DESCRIPTION
SQL Compare (quite reasonably!) has tests that check that all methods that process connection strings have the DoNotCaptureVariables attribute, to ensure we don't accidentally send any passwords back to Redgate. So, this microlibrary needs a way of adding those attributes, but without stopping it being consumed by projects that don't use SmartAssembly.