### PR TITLE
Rename extension method

### DIFF
--- a/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
+++ b/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
@@ -1,5 +1,10 @@
 # ULibs.SqlClientCompatibility release notes
 
+## 1.0.0
+
+### Features
+- Breaking change: extension method AddTrustServerCertificateForCompatibility has been renamed to SetBackwardsCompatibleTrustServerCertificateValue
+
 ## 0.1.1
 
 ### Features

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -32,7 +32,7 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
 #if SMARTASSEMBLY
 [DoNotCaptureVariables]
 #endif
-        internal static void AddTrustServerCertificateForCompatibility(this SqlConnectionStringBuilder builder)
+        internal static void SetBackwardsCompatibleTrustServerCertificateValue(this SqlConnectionStringBuilder builder)
         {
             var encrypt = builder.Encrypt;
             var isAzureAuth = builder.Authentication != SqlAuthenticationMethod.NotSpecified &&
@@ -61,11 +61,11 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
 #if SMARTASSEMBLY
 [DoNotCaptureVariables]
 #endif
-        internal static void AddTrustServerCertificateForCompatibility(this DbConnectionStringBuilder builder)
+        internal static void SetBackwardsCompatibleTrustServerCertificateValue(this DbConnectionStringBuilder builder)
         {
             if (builder is SqlConnectionStringBuilder sqlBuilder)
             {
-                AddTrustServerCertificateForCompatibility(sqlBuilder);
+                SetBackwardsCompatibleTrustServerCertificateValue(sqlBuilder);
             }
             else
             {
@@ -103,10 +103,10 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
 #if SMARTASSEMBLY
 [DoNotCaptureVariables]
 #endif
-        internal static string AddTrustServerCertificateForCompatibility(this string connectionString)
+        internal static string SetBackwardsCompatibleTrustServerCertificateValue(this string connectionString)
         {
             var builder = new DbConnectionStringBuilder {ConnectionString = connectionString};
-            builder.AddTrustServerCertificateForCompatibility();
+            builder.SetBackwardsCompatibleTrustServerCertificateValue();
             return builder.ConnectionString;
         }
 

--- a/Source/Ulibs.Tests/SqlClientCompatibility/TrustServerCertificateTests.cs
+++ b/Source/Ulibs.Tests/SqlClientCompatibility/TrustServerCertificateTests.cs
@@ -53,7 +53,7 @@ namespace Ulibs.Tests.SqlClientCompatibility
                 Encrypt = encrypt,
                 Authentication = auth
             };
-            builder.AddTrustServerCertificateForCompatibility();
+            builder.SetBackwardsCompatibleTrustServerCertificateValue();
             return builder.TrustServerCertificate;
         }
 
@@ -95,7 +95,7 @@ namespace Ulibs.Tests.SqlClientCompatibility
                 builder["Authentication"] = auth;
             }
 
-            builder.AddTrustServerCertificateForCompatibility();
+            builder.SetBackwardsCompatibleTrustServerCertificateValue();
             return new SqlConnectionStringBuilder(builder.ConnectionString).TrustServerCertificate;
         }
 
@@ -107,7 +107,7 @@ namespace Ulibs.Tests.SqlClientCompatibility
         [TestCase("Server=localhost;encrypt=yes", "Server=localhost;encrypt=yes")]
         public void AddTrustServerCertificateForCompatibility(string input, string expected)
         {
-            var actual = input.AddTrustServerCertificateForCompatibility();
+            var actual = input.SetBackwardsCompatibleTrustServerCertificateValue();
             Assert.That(actual, Is.EqualTo(expected).IgnoreCase);
         }
     }


### PR DESCRIPTION
This PR renames the `AddTrustServerCertificateForCompatibility` extension method to  `SetBackwardsCompatibleTrustServerCertificateValue` and bumps the major version for a breaking api change.