### PR TITLE
Fix SqlClientCompatibility for Microsoft.Data.SqlClient v4+

### DIFF
--- a/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
+++ b/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # ULibs.SqlClientCompatibility release notes
 
+## 1.0.2
+
+### Fixes
+- Fixed SetBackwardsCompatibleTrustServerCertificateValue when a SqlConnectionStringBuilder from Microsoft.Data.SqlClient v4+ is passed in
+- Removed ShouldTrustServerCertificate from the public API, as it wasn't intended to be exposed and isn't used externally anywhere
+
 ## 1.0.1
 
 ### Fixes

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -40,7 +40,14 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             var cleanBuilder = new DbConnectionStringBuilder { ConnectionString = builder.ConnectionString };
             if (ShouldTrustServerCertificate(cleanBuilder))
             {
-                builder["Trust Server Certificate"] = "true";
+                if (builder is SqlConnectionStringBuilder sqlBuilder)
+                {
+                    sqlBuilder.TrustServerCertificate = true;
+                }
+                else
+                {
+                    builder["Trust Server Certificate"] = "true";
+                }
             }
         }
 

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -34,9 +34,9 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
 #endif
         internal static void SetBackwardsCompatibleTrustServerCertificateValue(this DbConnectionStringBuilder builder)
         {
-            // SqlConnectionStringBuilder overrides ContainsKey and [] so we always get back true
-            // and the default value, so we can't tell whether keys were explicitly specified. By
-            // inspecting the connection string itself, we can tell whether key are actually set.
+            // SqlConnectionStringBuilder overrides ContainsKey and [], so we always get back true and
+            // the default value respectively, so we can't tell whether keys were explicitly specified.
+            // By inspecting the connection string itself, we can tell whether keys are actually set.
             var cleanBuilder = new DbConnectionStringBuilder { ConnectionString = builder.ConnectionString };
             if (ShouldTrustServerCertificate(cleanBuilder))
             {

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -150,6 +150,9 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             return null;
         }
 
+#if SMARTASSEMBLY
+[DoNotCaptureVariables]
+#endif
         private static bool ShouldTrustServerCertificate(DbConnectionStringBuilder builder)
         {
             var encrypt = builder.EncryptIsSet();

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -62,8 +62,13 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
 #endif
         internal static string SetBackwardsCompatibleTrustServerCertificateValue(this string connectionString)
         {
-            var builder = new DbConnectionStringBuilder {ConnectionString = connectionString};
-            builder.SetBackwardsCompatibleTrustServerCertificateValue();
+            var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+
+            if (ShouldTrustServerCertificate(builder))
+            {
+                builder["Trust Server Certificate"] = "true";
+            }
+
             return builder.ConnectionString;
         }
 

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -163,20 +163,10 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             return ShouldTrustServerCertificate(encrypt, isAzureAuth, trustServerCertificateAlreadySpecified, server);
         }
 
-        /// <summary>
-        /// <para>
-        /// System.Data.SqlClient didn't verify the certificate when connecting to a SQL Server using TLS,
-        /// unless the Encrypt connection property is set to true. In Microsoft.Data.SqlClient 2.0.0, this
-        /// behaviour has changed to always verify the server certificate. This could be disruptive to
-        /// customers, so we have decided to go for a middle ground: skip verification for on-premise SQL
-        /// Servers, that are being connected to over the LAN, when Encrypt is not set.
-        /// </para><para>
-        /// We should revisit this in the future; as encryption becomes more commonplace and more important,
-        /// even on LAN connections, verifying the server certificate should be enabled all the time. TBH,
-        /// this should already be the case in 2020!
-        /// </para>
-        /// </summary>
-        internal static bool ShouldTrustServerCertificate(
+        // This is internal so that it can be seen by the tests, but as it's a microlibrary,
+        // internal is effectively public, and this shouldn't be on the public interface.
+        /***private //***/internal
+            static bool ShouldTrustServerCertificate(
             bool encrypt,
             bool isAzureAuth,
             bool trustServerCertificateAlreadySpecified,

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -38,12 +38,7 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             // and the default value, so we can't tell whether keys were explicitly specified. By
             // inspecting the connection string itself, we can tell whether key are actually set.
             var cleanBuilder = new DbConnectionStringBuilder { ConnectionString = builder.ConnectionString };
-            var encrypt = cleanBuilder.EncryptIsSet();
-            var isAzureAuth = cleanBuilder.IsAzureAuth();
-            var server = cleanBuilder.GetServer();
-            var trustServerCertificateAlreadySpecified = cleanBuilder.IsTrustServerCertificateAlreadySpecified();
-
-            if (ShouldTrustServerCertificate(encrypt, isAzureAuth, trustServerCertificateAlreadySpecified, server))
+            if (ShouldTrustServerCertificate(cleanBuilder))
             {
                 builder["Trust Server Certificate"] = "true";
             }
@@ -141,6 +136,16 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             if (builder.TryGetValue("address", out var ad) && ad is string ads) return ads;
             if (builder.TryGetValue("network address", out var nad) && nad is string nads) return nads;
             return null;
+        }
+
+        private static bool ShouldTrustServerCertificate(DbConnectionStringBuilder builder)
+        {
+            var encrypt = builder.EncryptIsSet();
+            var isAzureAuth = builder.IsAzureAuth();
+            var server = builder.GetServer();
+            var trustServerCertificateAlreadySpecified = builder.IsTrustServerCertificateAlreadySpecified();
+
+            return ShouldTrustServerCertificate(encrypt, isAzureAuth, trustServerCertificateAlreadySpecified, server);
         }
 
         /// <summary>

--- a/Source/ULibs.SqlClientCompatibility/ULibs.SqlClientCompatibility.csproj
+++ b/Source/ULibs.SqlClientCompatibility/ULibs.SqlClientCompatibility.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/Ulibs.Tests/SqlClientCompatibility/TrustServerCertificateTests.cs
+++ b/Source/Ulibs.Tests/SqlClientCompatibility/TrustServerCertificateTests.cs
@@ -39,20 +39,31 @@ namespace Ulibs.Tests.SqlClientCompatibility
         [TestCase(false, SqlAuthenticationMethod.ActiveDirectoryInteractive, "(local)", ExpectedResult = false)]
         [TestCase(false, SqlAuthenticationMethod.ActiveDirectoryPassword, "(local)", ExpectedResult = false)]
         [TestCase(false, SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, "(local)", ExpectedResult = false)]
+        [TestCase(null, SqlAuthenticationMethod.ActiveDirectoryIntegrated, "(local)", ExpectedResult = false)]
+        [TestCase(null, SqlAuthenticationMethod.ActiveDirectoryInteractive, "(local)", ExpectedResult = false)]
+        [TestCase(null, SqlAuthenticationMethod.ActiveDirectoryPassword, "(local)", ExpectedResult = false)]
+        [TestCase(null, SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, "(local)", ExpectedResult = false)]
         // Don't trust: not on LAN
         [TestCase(false, SqlAuthenticationMethod.NotSpecified, "example.com", ExpectedResult = false)]
         [TestCase(false, SqlAuthenticationMethod.SqlPassword, "example.com", ExpectedResult = false)]
+        [TestCase(null, SqlAuthenticationMethod.NotSpecified, "example.com", ExpectedResult = false)]
+        [TestCase(null, SqlAuthenticationMethod.SqlPassword, "example.com", ExpectedResult = false)]
         // Do trust: on LAN
         [TestCase(false, SqlAuthenticationMethod.NotSpecified, "(local)", ExpectedResult = true)]
         [TestCase(false, SqlAuthenticationMethod.SqlPassword, "(local)", ExpectedResult = true)]
-        public bool AddShouldTrustServerCertificateToSqlConnectionStringBuilder(bool encrypt, SqlAuthenticationMethod auth, string server)
+        [TestCase(null, SqlAuthenticationMethod.NotSpecified, "(local)", ExpectedResult = true)]
+        [TestCase(null, SqlAuthenticationMethod.SqlPassword, "(local)", ExpectedResult = true)]
+        public bool AddShouldTrustServerCertificateToSqlConnectionStringBuilder(bool? encrypt, SqlAuthenticationMethod auth, string server)
         {
             var builder = new SqlConnectionStringBuilder
             {
                 DataSource = server,
-                Encrypt = encrypt,
                 Authentication = auth
             };
+            if (encrypt.HasValue)
+            {
+                builder.Encrypt = encrypt.Value;
+            }
             builder.SetBackwardsCompatibleTrustServerCertificateValue();
             return builder.TrustServerCertificate;
         }

--- a/Source/Ulibs.Tests/SqlClientCompatibility/TrustServerCertificateTests.cs
+++ b/Source/Ulibs.Tests/SqlClientCompatibility/TrustServerCertificateTests.cs
@@ -9,26 +9,36 @@ namespace Ulibs.Tests.SqlClientCompatibility
     public class TrustServerCertificateTests
     {
         // Don't trust: client requested encryption
-        [TestCase(true, false, "(local)", ExpectedResult = false)]
+        [TestCase(true, false, false, "(local)", ExpectedResult = false)]
         // Don't trust: azure auth
-        [TestCase(false, true, "(local)", ExpectedResult = false)]
+        [TestCase(false, true, false, "(local)", ExpectedResult = false)]
         // Don't trust: not on LAN
-        [TestCase(false, false, "8.8.8.8", ExpectedResult = false)]
-        [TestCase(false, false, "8.8.8.8\\sql2014", ExpectedResult = false)]
-        [TestCase(false, false, "example.com", ExpectedResult = false)]
-        [TestCase(false, false, "example.com\\sql2014", ExpectedResult = false)]
+        [TestCase(false, false, false, "8.8.8.8", ExpectedResult = false)]
+        [TestCase(false, false, false, "8.8.8.8\\sql2014", ExpectedResult = false)]
+        [TestCase(false, false, false, "example.com", ExpectedResult = false)]
+        [TestCase(false, false, false, "example.com\\sql2014", ExpectedResult = false)]
         // Do trust: on LAN
-        [TestCase(false, false, "localhost", ExpectedResult = true)]
-        [TestCase(false, false, "localhost\\sql2014", ExpectedResult = true)]
-        [TestCase(false, false, "(local)", ExpectedResult = true)]
-        [TestCase(false, false, "(local)\\sql2014", ExpectedResult = true)]
-        [TestCase(false, false, ".", ExpectedResult = true)]
-        [TestCase(false, false, ".\\sql2014", ExpectedResult = true)]
-        [TestCase(false, false, "192.168.1.120", ExpectedResult = true)]
-        [TestCase(false, false, "192.168.1.120\\sql2014", ExpectedResult = true)]
-        public bool ShouldTrustServerCertificate(bool encrypt, bool isAzureAuth, string server)
+        [TestCase(false, false, false, "localhost", ExpectedResult = true)]
+        [TestCase(false, false, false, "localhost\\sql2014", ExpectedResult = true)]
+        [TestCase(false, false, false, "(local)", ExpectedResult = true)]
+        [TestCase(false, false, false, "(local)\\sql2014", ExpectedResult = true)]
+        [TestCase(false, false, false, ".", ExpectedResult = true)]
+        [TestCase(false, false, false, ".\\sql2014", ExpectedResult = true)]
+        [TestCase(false, false, false, "192.168.1.120", ExpectedResult = true)]
+        [TestCase(false, false, false, "192.168.1.120\\sql2014", ExpectedResult = true)]
+        // Don't override: Trust Server Certificate is already specified
+        [TestCase(false, false, true, "localhost", ExpectedResult = false)]
+        public bool ShouldTrustServerCertificate(
+            bool encrypt,
+            bool isAzureAuth,
+            bool trustServerCertificateAlreadySpecified,
+            string server)
         {
-            return TrustServerCertificate.ShouldTrustServerCertificate(encrypt, isAzureAuth, server);
+            return TrustServerCertificate.ShouldTrustServerCertificate(
+                encrypt,
+                isAzureAuth,
+                trustServerCertificateAlreadySpecified,
+                server);
         }
 
         // Don't trust: client requested encryption


### PR DESCRIPTION
The behaviour of `SetBackwardsCompatibleTrustServerCertificateValue` when called on a `SqlConnectionStringBuilder` from Microsoft.Data.SqlClient v4+ was not as intended due to the changed default value of the `Encrypt` property. This PR changes the implementation to always deal with the connection string, so that it's immune to changes in default values of properties.