### PR TITLE
remove mention of Microsoft.Data.SqlClient from Ulib.SqlClientCompatibility

### DIFF
--- a/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
+++ b/Source/ULibs.SqlClientCompatibility/RELEASENOTES.md
@@ -1,5 +1,9 @@
 # ULibs.SqlClientCompatibility release notes
 
+## 3.1.0
+
+- Removed mention of Microsoft.Data.SqlClient from the included source code. The library should no longer force the consumer to reference a specific version of SqlClient
+
 ## 3.0.0
 - Removed Microsoft.Data.SqlClient dependency from the nuspec. The inlined code should build against the consumer's version of SqlClient
 

--- a/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
+++ b/Source/ULibs.SqlClientCompatibility/TrustServerCertificate.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using Microsoft.Data.SqlClient;
 #if SMARTASSEMBLY
 using SmartAssembly.Attributes;
 #endif
@@ -40,14 +39,7 @@ namespace /***$rootnamespace$.***/ULibs.SqlClientCompatibility
             var cleanBuilder = new DbConnectionStringBuilder { ConnectionString = builder.ConnectionString };
             if (ShouldTrustServerCertificate(cleanBuilder))
             {
-                if (builder is SqlConnectionStringBuilder sqlBuilder)
-                {
-                    sqlBuilder.TrustServerCertificate = true;
-                }
-                else
-                {
-                    builder["Trust Server Certificate"] = "true";
-                }
+                builder["Trust Server Certificate"] = "true";
             }
         }
 

--- a/Source/Ulibs.Tests/Ulibs.Tests.csproj
+++ b/Source/Ulibs.Tests/Ulibs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <Copyright>2018-2020</Copyright>
   </PropertyGroup>
 


### PR DESCRIPTION
part of https://github.com/red-gate/RedGate.SqlServer.ConnectionControl/issues/248

wider context: https://github.com/red-gate/SQLCompareUIs/issues/1444

rationale:
- SqlClient respects both the `"Trust Server Certificate"` and `"TrustServerCertificate"` properties. In theory, this change could cause some ambiguity if `"TrustServerCertificate"` were already set elsewhere somewhere in the connection string, and we were introducing a competing property.
  - (it may be that SqlConnectionStringBuilder already handles this case)
- However, `ShouldTrustServerCertificate` always returns `false` if either `"Trust Server Certificate"` and `"TrustServerCertificate"` is already set in the connection string, so we wouldn't attempt to change the property in this case
- therefore, I think this should be a safe change (ie manually setting `"Trust Server Certificate"` via `DbConnectionStringBuilder` should always do the thing we want)

not sure if there's any more unit tests I could write beyond what already exist to defend this change